### PR TITLE
[Feat] Jwt 인증 필터 추가 및 User entity 필드 추가

### DIFF
--- a/domo-back/build.gradle
+++ b/domo-back/build.gradle
@@ -7,6 +7,12 @@ plugins {
 group = 'next.domo'
 version = '1.0-SNAPSHOT'
 
+java {
+    toolchain {
+        languageVersion = JavaLanguageVersion.of(17)
+    }
+}
+
 repositories {
     mavenCentral()
 }

--- a/domo-back/src/main/java/next/domo/config/SecurityConfig.java
+++ b/domo-back/src/main/java/next/domo/config/SecurityConfig.java
@@ -1,15 +1,45 @@
 package next.domo.config;
 
+import lombok.RequiredArgsConstructor;
+import next.domo.jwt.JwtAuthenticationFilter;
+import next.domo.jwt.JwtProvider;
+import next.domo.user.UserRepository;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
+import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
 import org.springframework.security.web.SecurityFilterChain;
 import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
 import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.security.web.authentication.UsernamePasswordAuthenticationFilter;
+import org.springframework.web.cors.CorsConfiguration;
+import org.springframework.web.cors.CorsConfigurationSource;
+import org.springframework.web.cors.UrlBasedCorsConfigurationSource;
+
+import java.util.Arrays;
 
 
 @Configuration
+@EnableWebSecurity
+@RequiredArgsConstructor
 public class SecurityConfig {
+    private final JwtProvider jwtProvider;
+    private final UserRepository userRepository;
+
+    @Bean
+    public SecurityFilterChain filterChain(HttpSecurity http) throws Exception {
+        http
+                .cors(cors -> cors.configurationSource(corsConfigurationSource()))
+                .csrf(csrf -> csrf.disable()) // CSRF 비활성화 (API 테스트용)
+                .authorizeHttpRequests(authorize -> authorize
+                        .requestMatchers("/swagger-ui/**", "/v3/api-docs/**", "/swagger-ui.html", "/swagger-resources/**", "/webjars/**", "/api/user/signup", "/api/user/login"
+                ).permitAll() // 스웨거 허용
+                .anyRequest().authenticated() // 나머지는 인증 필요
+            )
+            .formLogin(form -> form.disable()) // 기본 로그인폼 끄기
+            .addFilterBefore(jwtAuthenticationProcessingFilter(), UsernamePasswordAuthenticationFilter.class);
+    return http.build();
+    }
 
     @Bean
     public PasswordEncoder passwordEncoder() {
@@ -17,23 +47,22 @@ public class SecurityConfig {
     }
 
     @Bean
-    public SecurityFilterChain filterChain(HttpSecurity http) throws Exception {
-        http
-            .csrf(csrf -> csrf.disable()) // CSRF 비활성화 (API 테스트용)
-            .authorizeHttpRequests(authorize -> authorize
-                .requestMatchers(
-                    "/swagger-ui/**",
-                    "/v3/api-docs/**",
-                    "/swagger-ui.html",
-                    "/swagger-resources/**",
-                    "/webjars/**",
-                    "/api/user/signup",
-                    "/api/user/login"
-                ).permitAll() // 스웨거 허용
-                .anyRequest().authenticated() // 나머지는 인증 필요
-            )
-            .formLogin(form -> form.disable()); // 기본 로그인폼 끄기
+    public JwtAuthenticationFilter jwtAuthenticationProcessingFilter() {
+        JwtAuthenticationFilter jwtAuthenticationFilter = new JwtAuthenticationFilter(jwtProvider, userRepository);
+        return jwtAuthenticationFilter;
+    }
 
-        return http.build();
+
+    @Bean
+    public CorsConfigurationSource corsConfigurationSource() {
+        CorsConfiguration configuration = new CorsConfiguration();
+        configuration.addAllowedOriginPattern("*");
+        configuration.addAllowedMethod("*"); // 모든 HTTP 메서드 허용
+        configuration.addAllowedHeader("*"); // 모든 헤더 허용
+        configuration.setAllowCredentials(true); // 쿠키 포함 허용
+        configuration.setExposedHeaders(Arrays.asList("Authorization", "Authorization-refresh"));
+        UrlBasedCorsConfigurationSource source = new UrlBasedCorsConfigurationSource();
+        source.registerCorsConfiguration("/**", configuration);
+        return source;
     }
 }

--- a/domo-back/src/main/java/next/domo/config/SwaggerConfig.java
+++ b/domo-back/src/main/java/next/domo/config/SwaggerConfig.java
@@ -1,7 +1,10 @@
 package next.domo.config;
 
+import io.swagger.v3.oas.models.Components;
 import io.swagger.v3.oas.models.OpenAPI;
 import io.swagger.v3.oas.models.info.Info;
+import io.swagger.v3.oas.models.security.SecurityRequirement;
+import io.swagger.v3.oas.models.security.SecurityScheme;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 
@@ -11,8 +14,35 @@ public class SwaggerConfig {
     @Bean
     public OpenAPI openAPI() {
         return new OpenAPI()
+                .components(new Components()
+                        .addSecuritySchemes("accessToken", new SecurityScheme()
+                                .name("Authorization") // 헤더 이름
+                                .type(SecurityScheme.Type.HTTP)
+                                .scheme("bearer")
+                                .bearerFormat("JWT")
+                        )
+                )
+                .addSecurityItem(new SecurityRequirement().addList("accessToken"))
                 .info(new Info()
                         .title("NE:XT DoMo 프로젝트 API 문서")
-                        .version("v1.0.0"));
+                        .version("v1.0.0")
+                        .description("회원가입 (/api/user/signup), 로그인 (/api/user/login) 시, accessToken과 refreshToken 모두 헤더로 전달\n" +
+                                "(accessToken - Authorization 헤더, refreshToken - Authorization-refresh 헤더)\n" +
+                                "\n" +
+                                "accessToken 만료시,\n" +
+                                "{\n" +
+                                "    \"error\": \"엑세스 토큰이 유효하지 않습니다.\"\n" +
+                                "}\n" +
+                                "반환\n" +
+                                "\n" +
+                                "refreshToken 만료시,\n" +
+                                "{\n" +
+                                "    \"error\": \"리프레시 토큰이 유효하지 않습니다.\"\n" +
+                                "}\n" +
+                                "반환\n" +
+                                "\n" +
+                                "/api/user/signup, /api/user/login을 제외한 모든 api에서 accessToken을 Authorization 헤더에 담아 요청\n" +
+                                "accessToken 만료시, refreshToken을 Authorization-refresh 헤더에 담아 요청 -> Authorization 헤더로 accessToken 반환")
+                );
     }
 }

--- a/domo-back/src/main/java/next/domo/jwt/JwtAuthenticationFilter.java
+++ b/domo-back/src/main/java/next/domo/jwt/JwtAuthenticationFilter.java
@@ -1,0 +1,116 @@
+package next.domo.jwt;
+
+import com.auth0.jwt.exceptions.JWTVerificationException;
+import jakarta.servlet.FilterChain;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import next.domo.user.User;
+import next.domo.user.UserRepository;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.authority.mapping.GrantedAuthoritiesMapper;
+import org.springframework.security.core.authority.mapping.NullAuthoritiesMapper;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.security.core.userdetails.UserDetails;
+import org.springframework.web.filter.OncePerRequestFilter;
+
+import java.io.IOException;
+import java.util.List;
+
+@RequiredArgsConstructor
+@Slf4j
+public class JwtAuthenticationFilter extends OncePerRequestFilter {
+
+    private static final List<String> NO_CHECK_URLS = List.of("/api/user/login", "/swagger-ui", "/api/user/signup", "/v3/api-docs", "/oauth2/google/login", "/oauth2/kakao/login", "/oauth2/apple/login");
+
+    public final JwtProvider jwtProvider;
+    public final UserRepository userRepository;
+
+    private GrantedAuthoritiesMapper authoritiesMapper = new NullAuthoritiesMapper();
+
+    @Override
+    protected void doFilterInternal(HttpServletRequest request, HttpServletResponse response, FilterChain filterChain)
+            throws ServletException, IOException {
+
+        String requestUrl = request.getRequestURI();
+
+        // NO_CHECK_URLS에 해당 requestUrl이 있는 경우
+        // JWT 검증 로직 없이 filter 통과
+        if (NO_CHECK_URLS.stream().anyMatch(requestUrl::startsWith)) {
+            filterChain.doFilter(request, response);
+            return;
+        }
+
+        String accessToken= jwtProvider.extractAccessToken(request).orElse(null);
+        String refreshToken = jwtProvider.extractRefreshToken(request).orElse(null);
+
+        try{
+            // token이 비어있음
+            if(accessToken == null && refreshToken == null) {
+                log.error("액세스 토큰과 리프레시 토큰이 모두 존재하지 않습니다.");
+                throw new JWTVerificationException("액세스 토큰과 리프레시 토큰이 모두 존재하지 않습니다.");
+            }
+            // accesstoken 유효
+            if(accessToken != null && jwtProvider.isAccessTokenValid(accessToken)) {
+                checkAccessTokenAndAuthentication(request, response, filterChain);
+                return;
+            }
+            // refreshtoken 유효 -> accesstoken 재발급
+            if(refreshToken != null && jwtProvider.isRefreshTokenValid(refreshToken)) {
+                reIssueAccessToken(response, refreshToken);
+                return;
+            }
+        }
+        catch (JWTVerificationException e) {
+            log.error("JWT 검증 실패: {}", e.getMessage());
+            response.setStatus(HttpServletResponse.SC_UNAUTHORIZED);
+            response.setContentType("application/json; charset=UTF-8");
+            response.setCharacterEncoding("UTF-8");
+            String errorMessage = String.format("{\"errorCode\": \"%d\", \"error\": \"%s\"}", e.getMessage());
+            response.getWriter().write(errorMessage);
+        }
+
+    }
+
+    public void reIssueAccessToken(HttpServletResponse response, String refreshToken) throws IOException {
+        log.info("리프레시토큰이 유효하나 DB에 있는지는 모름. DB에서 찾아봐서 없으면 예외 발생할 것임.");
+        User user = userRepository.findByRefreshToken(refreshToken)
+                .orElseThrow(() -> new JWTVerificationException("유효하지 않은 리프레시 토큰입니다."));
+        jwtProvider.sendAccessToken(response, jwtProvider.createAccessToken(user.getLoginId(), user.getUserId()));
+    }
+
+    public void checkAccessTokenAndAuthentication(HttpServletRequest request, HttpServletResponse response,
+                                                  FilterChain filterChain) throws ServletException, IOException {
+        log.info("checkAccessTokenAndAuthentication() 호출");
+        jwtProvider.extractAccessToken(request)
+                .ifPresent(accessToken -> {
+                    jwtProvider.extractUserId(accessToken)
+                            .ifPresent(userId -> userRepository.findByUserId(userId)
+                                    .ifPresent(this::saveAuthentication)
+                            );
+                });
+
+        filterChain.doFilter(request, response);
+    }
+
+    // 인증 허가
+    public void saveAuthentication(User myUser) {
+        String password = myUser.getPassword();
+
+        UserDetails userDetailsUser = org.springframework.security.core.userdetails.User.builder()
+                .username(myUser.getLoginId())
+                .password(password)
+                .build();
+
+        Authentication authentication =
+                new UsernamePasswordAuthenticationToken(userDetailsUser, null,
+                        authoritiesMapper.mapAuthorities(userDetailsUser.getAuthorities()));
+
+        SecurityContextHolder.getContext().setAuthentication(authentication);
+    }
+
+
+}

--- a/domo-back/src/main/java/next/domo/user/User.java
+++ b/domo-back/src/main/java/next/domo/user/User.java
@@ -24,6 +24,11 @@ public class User {
     private String name;
     private String email;
     private String refreshToken;
+    private int userCoin;
+    private int detailPreference;
+    private int workPace;
+    private String characterName;
+    private String characterFileUrl;
 
     public void updateRefreshToken(String newRefreshToken){
         this.refreshToken = newRefreshToken;

--- a/domo-back/src/main/java/next/domo/user/UserRepository.java
+++ b/domo-back/src/main/java/next/domo/user/UserRepository.java
@@ -11,4 +11,5 @@ public interface UserRepository extends JpaRepository<User, Long> {
     Optional<User> findByUserId(Long userId);
     Optional<User> findByLoginId(String loginId);
     Optional<User> findByEmail(String email);
+    Optional<User> findByRefreshToken(String refreshToken);
 }


### PR DESCRIPTION
## 추가한 코드
- SecurityConfig
  - CORS 설정) 모든 도메인에 대해 모든 요청을 허용, 쿠키 전송 허용 + 특정 응답 헤더 노출
  - `addFilterBefore(jwtAuthenticationProcessingFilter(), UsernamePasswordAuthenticationFilter.class)`
    - UsernamePasswordAuthenticationFilter -  원래 폼 로그인(Form Login)을 처리하는 필터
    - 폼로그인을 사용하지 X
    - Spring Security 필터 체인 안에서 기준점으로서의 역할 -> JWT 인증 필터를 “언제 실행할지” 지정
  - SwaggerConfig
    - token 관련 설명 추가
      - 회원가입 (/api/user/signup), 로그인 (/api/user/login) 시, accessToken과 refreshToken 모두 헤더로 전달
      - (accessToken - Authorization 헤더, refreshToken - Authorization-refresh 헤더)
      - accessToken 만료시, 아래와 같이 반환
      ```
        {
            "error": "엑세스 토큰이 유효하지 않습니다."
        }
      ```
      - refreshToken 만료시, 아래와 같이 반환
      ```
      {
          "error": "리프레시 토큰이 유효하지 않습니다."
      }
      ```
      - /api/user/signup, /api/user/login을 제외한 모든 api에서 accessToken을 Authorization 헤더에 담아 요청
      - accessToken 만료시, refreshToken을 Authorization-refresh 헤더에 담아 요청 -> Authorization 헤더로 accessToken 반환
  - JwtAuthenticationFilter
      - token이 비어있음 -> 에러
      - accesstoken 유효 -> 진행
      - refreshtoken 유효 -> accesstoken 재발급
- User
  -  userCoin, detailPreference, workPace, characterName, characterFileUrl 속성 추가