### PR TITLE
feat: Project, ProjectTag 관련 기능 추가 및 비밀번호 수정, 회원 탈퇴 기능 수정

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,4 @@
+{
+    "java.configuration.updateBuildConfiguration": "automatic",
+    "java.compile.nullAnalysis.mode": "automatic"
+}

--- a/domo-back/src/main/java/next/domo/project/controller/ProjectController.java
+++ b/domo-back/src/main/java/next/domo/project/controller/ProjectController.java
@@ -1,0 +1,88 @@
+package next.domo.project.controller;
+
+import lombok.RequiredArgsConstructor;
+import next.domo.project.dto.*;
+import next.domo.project.service.ProjectService;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import io.swagger.v3.oas.annotations.security.SecurityRequirement;
+
+import java.util.List;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/project")
+@SecurityRequirement(name = "accessToken")
+public class ProjectController {
+
+    private final ProjectService projectService;
+
+    @Operation(summary = "프로젝트 생성")
+    @ApiResponses({
+        @ApiResponse(responseCode = "200", description = "프로젝트 생성 성공"),
+        @ApiResponse(responseCode = "400", description = "프로젝트 생성 실패")
+    })
+    @PostMapping
+    public ResponseEntity<String> createProject(@RequestBody ProjectCreateRequestDto requestDto) {
+        projectService.createProject(requestDto);
+        return ResponseEntity.ok("프로젝트 생성 성공!");
+    }
+
+    @Operation(summary = "모든 프로젝트 리스트 조회 (이름, 태그명, 데드라인)")
+    @ApiResponses({
+        @ApiResponse(responseCode = "200", description = "프로젝트 리스트 조회 성공"),
+        @ApiResponse(responseCode = "400", description = "프로젝트 리스트 조회 실패")
+    })
+    @GetMapping
+    public ResponseEntity<List<ProjectListResponseDto>> getAllProjects() {
+        List<ProjectListResponseDto> projects = projectService.getAllProjects();
+        return ResponseEntity.ok(projects);
+    }
+
+    @Operation(summary = "특정 프로젝트 상세 조회 (이름, 설명, 태그명, 데드라인)")
+    @ApiResponses({
+        @ApiResponse(responseCode = "200", description = "프로젝트 상세 조회 성공"),
+        @ApiResponse(responseCode = "400", description = "프로젝트 상세 조회 실패")
+    })
+    @GetMapping("/{projectId}")
+    public ResponseEntity<ProjectDetailResponseDto> getProjectDetail(@PathVariable Long projectId) {
+        ProjectDetailResponseDto detail = projectService.getProjectDetail(projectId);
+        return ResponseEntity.ok(detail);
+    }
+
+    @Operation(summary = "프로젝트 수정 (이름, 설명, 요구사항, 태그명, 데드라인 수정)")
+    @ApiResponses({
+        @ApiResponse(responseCode = "200", description = "프로젝트 수정 성공"),
+        @ApiResponse(responseCode = "400", description = "프로젝트 수정 실패")
+    })
+    @PutMapping("/{projectId}")
+    public ResponseEntity<String> updateProject(@PathVariable Long projectId, @RequestBody ProjectUpdateRequestDto requestDto) {
+        projectService.updateProject(projectId, requestDto);
+        return ResponseEntity.ok("프로젝트 수정 성공!");
+    }
+
+    @Operation(summary = "프로젝트 삭제")
+    @ApiResponses({
+        @ApiResponse(responseCode = "200", description = "프로젝트 삭제 성공"),
+        @ApiResponse(responseCode = "400", description = "프로젝트 삭제 실패")
+    })
+    @DeleteMapping("/{projectId}")
+    public ResponseEntity<String> deleteProject(@PathVariable Long projectId) {
+        projectService.deleteProject(projectId);
+        return ResponseEntity.ok("프로젝트 삭제 성공!");
+    }
+
+    @Operation(summary = "가장 최근 접속한 프로젝트 조회 (이름, 태그명)")
+    @ApiResponses({
+        @ApiResponse(responseCode = "200", description = "최근 프로젝트 조회 성공"),
+        @ApiResponse(responseCode = "400", description = "최근 프로젝트 조회 실패")
+    })
+    @GetMapping("/recent")
+    public ResponseEntity<ProjectRecentResponseDto> getRecentProject() {
+        ProjectRecentResponseDto recent = projectService.getRecentProject();
+        return ResponseEntity.ok(recent);
+    }
+}

--- a/domo-back/src/main/java/next/domo/project/controller/ProjectTagController.java
+++ b/domo-back/src/main/java/next/domo/project/controller/ProjectTagController.java
@@ -1,0 +1,56 @@
+package next.domo.project.controller;
+
+import lombok.RequiredArgsConstructor;
+import next.domo.project.dto.ProjectTagCreateRequestDto;
+import next.domo.project.dto.ProjectTagResponseDto;
+import next.domo.project.service.ProjectTagService;
+
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import io.swagger.v3.oas.annotations.security.SecurityRequirement;
+
+import java.util.List;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/project-tag")
+@SecurityRequirement(name = "accessToken")
+public class ProjectTagController {
+
+    private final ProjectTagService projectTagService;
+
+    @Operation(summary = "프로젝트 태그 생성")
+    @ApiResponses({
+        @ApiResponse(responseCode = "200", description = "프로젝트 태그 생성 성공"),
+        @ApiResponse(responseCode = "400", description = "프로젝트 태그 생성 실패 (중복 or 잘못된 입력)")
+    })
+    @PostMapping
+    public ResponseEntity<String> createProjectTag(@RequestBody ProjectTagCreateRequestDto requestDto) {
+        projectTagService.createProjectTag(requestDto.getProjectTagName());
+        return ResponseEntity.ok("프로젝트 태그 생성 성공!");
+    }
+
+    @Operation(summary = "내 프로젝트 태그 목록 조회")
+    @ApiResponses({
+        @ApiResponse(responseCode = "200", description = "프로젝트 태그 목록 조회 성공")
+    })
+    @GetMapping
+    public ResponseEntity<List<ProjectTagResponseDto>> getMyProjectTags() {
+        List<ProjectTagResponseDto> tags = projectTagService.getMyProjectTags();
+        return ResponseEntity.ok(tags);
+    }
+
+    @Operation(summary = "프로젝트 태그 삭제")
+    @ApiResponses({
+        @ApiResponse(responseCode = "200", description = "프로젝트 태그 삭제 성공"),
+        @ApiResponse(responseCode = "400", description = "프로젝트 태그 삭제 실패 (사용중인 프로젝트 존재)")
+    })
+    @DeleteMapping("/{projectTagId}")
+    public ResponseEntity<String> deleteProjectTag(@PathVariable Long projectTagId) {
+        projectTagService.deleteProjectTag(projectTagId);
+        return ResponseEntity.ok("프로젝트 태그 삭제 성공!");
+    }
+}

--- a/domo-back/src/main/java/next/domo/project/dto/ProjectCreateRequestDto.java
+++ b/domo-back/src/main/java/next/domo/project/dto/ProjectCreateRequestDto.java
@@ -1,0 +1,14 @@
+package next.domo.project.dto;
+
+import lombok.Getter;
+
+import java.time.LocalDateTime;
+
+@Getter
+public class ProjectCreateRequestDto {
+    private String projectName;
+    private String projectDescription;
+    private String projectRequirement;
+    private LocalDateTime projectDeadline;
+    private String projectTagName;
+}

--- a/domo-back/src/main/java/next/domo/project/dto/ProjectDetailResponseDto.java
+++ b/domo-back/src/main/java/next/domo/project/dto/ProjectDetailResponseDto.java
@@ -1,0 +1,15 @@
+package next.domo.project.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+import java.time.LocalDateTime;
+
+@Getter
+@AllArgsConstructor
+public class ProjectDetailResponseDto {
+    private String projectName;
+    private String projectDescription;
+    private String projectTagName;
+    private LocalDateTime projectDeadline;
+}

--- a/domo-back/src/main/java/next/domo/project/dto/ProjectListResponseDto.java
+++ b/domo-back/src/main/java/next/domo/project/dto/ProjectListResponseDto.java
@@ -1,0 +1,15 @@
+package next.domo.project.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+import java.time.LocalDateTime;
+
+@Getter
+@AllArgsConstructor
+public class ProjectListResponseDto {
+    private Long projectId;
+    private String projectName;
+    private String projectTagName;
+    private LocalDateTime projectDeadline;
+}

--- a/domo-back/src/main/java/next/domo/project/dto/ProjectRecentResponseDto.java
+++ b/domo-back/src/main/java/next/domo/project/dto/ProjectRecentResponseDto.java
@@ -1,0 +1,11 @@
+package next.domo.project.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+public class ProjectRecentResponseDto {
+    private String projectName;
+    private String projectTagName;
+}

--- a/domo-back/src/main/java/next/domo/project/dto/ProjectTagCreateRequestDto.java
+++ b/domo-back/src/main/java/next/domo/project/dto/ProjectTagCreateRequestDto.java
@@ -1,0 +1,8 @@
+package next.domo.project.dto;
+
+import lombok.Getter;
+
+@Getter
+public class ProjectTagCreateRequestDto {
+    private String projectTagName;
+}

--- a/domo-back/src/main/java/next/domo/project/dto/ProjectTagResponseDto.java
+++ b/domo-back/src/main/java/next/domo/project/dto/ProjectTagResponseDto.java
@@ -1,0 +1,11 @@
+package next.domo.project.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+public class ProjectTagResponseDto {
+    private Long projectTagId;
+    private String projectTagName;
+}

--- a/domo-back/src/main/java/next/domo/project/dto/ProjectUpdateRequestDto.java
+++ b/domo-back/src/main/java/next/domo/project/dto/ProjectUpdateRequestDto.java
@@ -1,0 +1,13 @@
+package next.domo.project.dto;
+
+import lombok.Getter;
+import java.time.LocalDateTime;
+
+@Getter
+public class ProjectUpdateRequestDto {
+    private String projectName;
+    private String projectDescription;
+    private String projectRequirement;
+    private String projectTagName;
+    private LocalDateTime projectDeadline;
+}

--- a/domo-back/src/main/java/next/domo/project/entity/Project.java
+++ b/domo-back/src/main/java/next/domo/project/entity/Project.java
@@ -1,0 +1,62 @@
+package next.domo.project.entity;
+
+import jakarta.persistence.*;
+import lombok.*;
+import java.time.LocalDateTime;
+
+@Entity
+@Table(name = "project")
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor
+@Builder
+public class Project {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long projectId;
+
+    private Long userId;
+
+    private Long projectTagId;
+
+    private String projectName;
+
+    @Column(columnDefinition = "TEXT")
+    private String projectDescription;
+
+    @Column(columnDefinition = "TEXT")
+    private String projectRequirement;
+
+    private LocalDateTime projectDeadline;
+
+    private Integer projectExpectedTime;
+
+    private Integer projectLevel;
+
+    private Integer projectCoin;
+
+    public void updateProject(String projectName, String projectDescription, String projectRequirement, LocalDateTime projectDeadline, Long projectTagId) {
+        this.projectName = projectName;
+        this.projectDescription = projectDescription;
+        this.projectRequirement = projectRequirement;
+        this.projectDeadline = projectDeadline;
+        this.projectTagId = projectTagId;
+    }
+
+    public void setProjectName(String projectName) {
+        this.projectName = projectName;
+    }
+    public void setProjectDescription(String projectDescription) {
+        this.projectDescription = projectDescription;
+    }
+    public void setProjectRequirement(String projectRequirement) {
+        this.projectRequirement = projectRequirement;
+    }
+    public void setProjectDeadline(LocalDateTime projectDeadline) {
+        this.projectDeadline = projectDeadline;
+    }
+    public void setProjectTagId(Long projectTagId) {
+        this.projectTagId = projectTagId;
+    }
+}

--- a/domo-back/src/main/java/next/domo/project/entity/ProjectTag.java
+++ b/domo-back/src/main/java/next/domo/project/entity/ProjectTag.java
@@ -1,0 +1,21 @@
+package next.domo.project.entity;
+
+import jakarta.persistence.*;
+import lombok.*;
+
+@Entity
+@Table(name = "project_tag")
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor
+@Builder
+public class ProjectTag {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long projectTagId;
+
+    private String projectTagName;
+
+    private Long userId;
+}

--- a/domo-back/src/main/java/next/domo/project/repository/ProjectRepository.java
+++ b/domo-back/src/main/java/next/domo/project/repository/ProjectRepository.java
@@ -1,0 +1,16 @@
+package next.domo.project.repository;
+
+import next.domo.project.entity.Project;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+import java.util.List;
+import java.util.Optional;
+
+@Repository
+public interface ProjectRepository extends JpaRepository<Project, Long> {
+    boolean existsByProjectTagId(Long projectTagId);
+    List<Project> findByUserId(Long userId);
+    Optional<Project> findTopByUserIdOrderByProjectIdDesc(Long userId);
+}
+

--- a/domo-back/src/main/java/next/domo/project/repository/ProjectTagRepository.java
+++ b/domo-back/src/main/java/next/domo/project/repository/ProjectTagRepository.java
@@ -1,0 +1,14 @@
+package next.domo.project.repository;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import next.domo.project.entity.ProjectTag;
+
+import java.util.List;
+import java.util.Optional;
+
+public interface ProjectTagRepository extends JpaRepository<ProjectTag, Long> {
+    boolean existsByProjectTagNameAndUserId(String projectTagName, Long userId);
+    Optional<ProjectTag> findByProjectTagNameAndUserId(String projectTagName, Long userId);
+    List<ProjectTag> findByUserId(Long userId);
+}

--- a/domo-back/src/main/java/next/domo/project/service/ProjectService.java
+++ b/domo-back/src/main/java/next/domo/project/service/ProjectService.java
@@ -1,0 +1,113 @@
+package next.domo.project.service;
+
+import lombok.RequiredArgsConstructor;
+import next.domo.project.dto.*;
+import next.domo.project.entity.Project;
+import next.domo.project.entity.ProjectTag;
+import next.domo.project.repository.ProjectRepository;
+import next.domo.project.repository.ProjectTagRepository;
+import next.domo.user.UserService;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+import java.util.stream.Collectors;
+
+@Service
+@RequiredArgsConstructor
+@Transactional
+public class ProjectService {
+
+    private final ProjectRepository projectRepository;
+    private final ProjectTagRepository projectTagRepository;
+    private final UserService userService;
+
+    public void createProject(ProjectCreateRequestDto requestDto) {
+        Long userId = userService.getCurrentUserId();
+
+        ProjectTag tag = projectTagRepository.findByProjectTagNameAndUserId(requestDto.getProjectTagName(), userId)
+                .orElseThrow(() -> new RuntimeException("해당 태그가 없습니다."));
+
+        Project project = Project.builder()
+                .userId(userId)
+                .projectTagId(tag.getProjectTagId())
+                .projectName(requestDto.getProjectName())
+                .projectDescription(requestDto.getProjectDescription())
+                .projectRequirement(requestDto.getProjectRequirement())
+                .projectDeadline(requestDto.getProjectDeadline())
+                .projectExpectedTime(0) // 하위 작업으로 합산 예정
+                .build();
+
+        projectRepository.save(project);
+    }
+
+    public List<ProjectListResponseDto> getAllProjects() {
+        Long userId = userService.getCurrentUserId();
+        return projectRepository.findByUserId(userId).stream()
+                .map(project -> {
+                    ProjectTag tag = projectTagRepository.findById(project.getProjectTagId())
+                            .orElseThrow(() -> new RuntimeException("태그를 찾을 수 없습니다."));
+                    return new ProjectListResponseDto(
+                            project.getProjectId(),
+                            project.getProjectName(),
+                            tag.getProjectTagName(),
+                            project.getProjectDeadline()
+                    );
+                }).collect(Collectors.toList());
+    }
+
+    public ProjectDetailResponseDto getProjectDetail(Long projectId) {
+        Project project = projectRepository.findById(projectId)
+                .orElseThrow(() -> new RuntimeException("프로젝트를 찾을 수 없습니다."));
+        ProjectTag tag = projectTagRepository.findById(project.getProjectTagId())
+                .orElseThrow(() -> new RuntimeException("태그를 찾을 수 없습니다."));
+        return new ProjectDetailResponseDto(
+                project.getProjectName(),
+                project.getProjectDescription(),
+                tag.getProjectTagName(),
+                project.getProjectDeadline()
+        );
+    }
+
+    public void updateProject(Long projectId, ProjectUpdateRequestDto requestDto) {
+        Project project = projectRepository.findById(projectId)
+                .orElseThrow(() -> new RuntimeException("프로젝트를 찾을 수 없습니다."));
+
+        // 입력된 값만 업데이트
+        if (requestDto.getProjectName() != null) {
+            project.setProjectName(requestDto.getProjectName());
+        }
+        if (requestDto.getProjectDescription() != null) {
+            project.setProjectDescription(requestDto.getProjectDescription());
+        }
+        if (requestDto.getProjectRequirement() != null) {
+            project.setProjectRequirement(requestDto.getProjectRequirement());
+        }
+        if (requestDto.getProjectDeadline() != null) {
+            project.setProjectDeadline(requestDto.getProjectDeadline());
+        }
+        if (requestDto.getProjectTagName() != null) {
+            ProjectTag tag = projectTagRepository.findByProjectTagNameAndUserId(requestDto.getProjectTagName(), project.getUserId())
+                    .orElseThrow(() -> new RuntimeException("해당 태그를 찾을 수 없습니다."));
+            project.setProjectTagId(tag.getProjectTagId());
+        }
+    }
+    public void deleteProject(Long projectId) {
+        projectRepository.deleteById(projectId);
+    }
+
+    public ProjectRecentResponseDto getRecentProject() {
+        Long userId = userService.getCurrentUserId();
+        Project recent = projectRepository.findTopByUserIdOrderByProjectIdDesc(userId)
+                .orElseThrow(() -> new RuntimeException("최근 프로젝트가 없습니다."));
+
+        ProjectTag tag = projectTagRepository.findById(recent.getProjectTagId())
+                .orElseThrow(() -> new RuntimeException("태그를 찾을 수 없습니다."));
+
+        return new ProjectRecentResponseDto(
+                recent.getProjectName(),
+                tag.getProjectTagName()
+        );
+    }
+}
+

--- a/domo-back/src/main/java/next/domo/project/service/ProjectTagService.java
+++ b/domo-back/src/main/java/next/domo/project/service/ProjectTagService.java
@@ -1,0 +1,62 @@
+package next.domo.project.service;
+
+import lombok.RequiredArgsConstructor;
+import next.domo.user.UserService;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import next.domo.project.dto.ProjectTagResponseDto;
+import next.domo.project.entity.ProjectTag;
+import next.domo.project.repository.ProjectTagRepository;
+import next.domo.project.repository.ProjectRepository;
+
+import java.util.List;
+import java.util.stream.Collectors;
+
+@Service
+@RequiredArgsConstructor
+@Transactional
+public class ProjectTagService {
+
+    private final ProjectTagRepository projectTagRepository;
+    private final ProjectRepository projectRepository;
+    private final UserService userService;
+
+    public void createProjectTag(String projectTagName) {
+        Long userId = userService.getCurrentUserId();
+
+        if (projectTagName == null || projectTagName.trim().isEmpty()) {
+            throw new IllegalArgumentException("프로젝트 태그 이름이 비어있습니다.");
+        }
+
+        boolean exists = projectTagRepository.existsByProjectTagNameAndUserId(projectTagName, userId);
+        if (exists) {
+            throw new RuntimeException("이미 존재하는 태그입니다.");
+        }
+
+        ProjectTag tag = ProjectTag.builder()
+                .userId(userId)
+                .projectTagName(projectTagName)
+                .build();
+        projectTagRepository.save(tag);
+    }
+
+    public List<ProjectTagResponseDto> getMyProjectTags() {
+        Long userId = userService.getCurrentUserId();
+        return projectTagRepository.findByUserId(userId).stream()
+                .map(tag -> new ProjectTagResponseDto(tag.getProjectTagId(), tag.getProjectTagName()))
+                .collect(Collectors.toList());
+    }
+
+    public void deleteProjectTag(Long projectTagId) {
+        boolean hasProject = projectRepository.existsByProjectTagId(projectTagId);
+    
+        if (hasProject) {
+            throw new RuntimeException("해당 태그를 사용하는 프로젝트가 있어 삭제할 수 없습니다. 먼저 프로젝트의 태그를 변경하세요.");
+        }
+    
+        ProjectTag tag = projectTagRepository.findById(projectTagId)
+                .orElseThrow(() -> new RuntimeException("프로젝트 태그를 찾을 수 없습니다."));
+    
+        projectTagRepository.delete(tag);
+    }
+}

--- a/domo-back/src/main/java/next/domo/user/UserController.java
+++ b/domo-back/src/main/java/next/domo/user/UserController.java
@@ -13,6 +13,7 @@ import org.springframework.web.bind.annotation.*;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import io.swagger.v3.oas.annotations.security.SecurityRequirement;
 
 @RestController
 @RequiredArgsConstructor
@@ -22,6 +23,7 @@ public class UserController {
     private final UserService userService;
 
     @Operation(summary = "회원가입")
+    @SecurityRequirement(name = "")
     @ApiResponses({
         @ApiResponse(responseCode = "200", description = "회원가입 성공"),
         @ApiResponse(responseCode = "400", description = "회원가입 실패 (아이디/이메일 중복)")
@@ -33,6 +35,7 @@ public class UserController {
     }
 
     @Operation(summary = "로그인")
+    @SecurityRequirement(name = "")
     @ApiResponses({
         @ApiResponse(responseCode = "200", description = "로그인 성공"),
         @ApiResponse(responseCode = "400", description = "로그인 실패 (아이디/비밀번호 불일치)")
@@ -44,24 +47,26 @@ public class UserController {
     }
 
     @Operation(summary = "비밀번호 변경")
+    @SecurityRequirement(name = "accessToken")
     @ApiResponses({
         @ApiResponse(responseCode = "200", description = "비밀번호 변경 성공"),
         @ApiResponse(responseCode = "400", description = "비밀번호 변경 실패 (기존 비밀번호 불일치)")
     })
     @PutMapping("/password")
-    public ResponseEntity<String> changePassword(@RequestParam String loginId, @RequestBody ChangePasswordRequestDto requestDto) {
-        userService.changePassword(loginId, requestDto);
+    public ResponseEntity<String> changePassword(@RequestBody ChangePasswordRequestDto requestDto) {
+        userService.changePassword(requestDto);
         return ResponseEntity.ok("비밀번호 변경 성공");
     }
-
+    
     @Operation(summary = "회원 탈퇴")
+    @SecurityRequirement(name = "accessToken")
     @ApiResponses({
         @ApiResponse(responseCode = "200", description = "회원 탈퇴 성공"),
         @ApiResponse(responseCode = "400", description = "회원 탈퇴 실패 (해당 아이디 없음)")
     })
     @DeleteMapping("/delete")
-    public ResponseEntity<String> deleteUser(@RequestParam String loginId) {
-        userService.deleteUser(loginId);
+    public ResponseEntity<String> deleteUser() {
+        userService.deleteUser();
         return ResponseEntity.ok("회원 탈퇴 성공");
     }
 }


### PR DESCRIPTION
- 비밀번호 변경, 회원 탈퇴 기능 수정 -> JwtAuthenticationFilter에서 토큰 받아서 userId 뽑아서 사용자 구분 (AccessToken 사용)
- 프로젝트 생성, 모든 프로젝트 리스트 조회 (이름, 태그명, 데드라인), 특정 프로젝트 상세 조회 (이름, 설명, 태그명, 데드라인), 프로젝트 수정 (이름, 설명, 요구사항, 태그명, 데드라인 수정 / 부분 수정 가능), 프로젝트 삭제, 가장 최근 접속한 프로젝트 조회 (이름, 태그명), 프로젝트 태그 생성, 내 프로젝트 태그 목록 조회, 프로젝트 태그 삭제 기능 구현