### PR TITLE
[Feat] S3 파일 업로드 및 캐릭터 파일 업로드/조회 기능 추가

### DIFF
--- a/domo-back/build.gradle
+++ b/domo-back/build.gradle
@@ -48,6 +48,11 @@ dependencies {
 
     // WebClient
     implementation 'org.springframework.boot:spring-boot-starter-webflux'
+
+    // aws-S3
+    implementation platform("software.amazon.awssdk:bom:2.20.150")
+    implementation 'software.amazon.awssdk:s3'
+    implementation 'software.amazon.awssdk:auth'
 }
 
 test {

--- a/domo-back/src/main/java/next/domo/config/SecurityConfig.java
+++ b/domo-back/src/main/java/next/domo/config/SecurityConfig.java
@@ -33,7 +33,7 @@ public class SecurityConfig {
                 .cors(cors -> cors.configurationSource(corsConfigurationSource()))
                 .csrf(csrf -> csrf.disable()) // CSRF 비활성화 (API 테스트용)
                 .authorizeHttpRequests(authorize -> authorize
-                        .requestMatchers("/swagger-ui/**", "/v3/api-docs/**", "/swagger-ui.html", "/swagger-resources/**", "/webjars/**", "/api/user/signup", "/api/user/login"
+                        .requestMatchers("/swagger-ui/**", "/v3/api-docs/**", "/swagger-ui.html", "/swagger-resources/**", "/webjars/**", "/api/user/signup", "/api/user/login", "/upload/glb"
                 ).permitAll() // 스웨거 허용
                 .anyRequest().authenticated() // 나머지는 인증 필요
             )

--- a/domo-back/src/main/java/next/domo/upload/controller/UploadController.java
+++ b/domo-back/src/main/java/next/domo/upload/controller/UploadController.java
@@ -1,0 +1,32 @@
+package next.domo.upload.controller;
+
+import lombok.RequiredArgsConstructor;
+import next.domo.upload.service.S3Service;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+import org.springframework.web.multipart.MultipartFile;
+
+import java.util.List;
+
+@RestController
+@RequestMapping("/upload")
+@RequiredArgsConstructor
+public class UploadController {
+
+    private final S3Service s3Service;
+
+    private static final List<String> allowedTypes = List.of("character", "item", "quest");
+
+    @PostMapping("/{type}")
+    public ResponseEntity<String> uploadFileByType(
+            @PathVariable String type,
+            @RequestPart MultipartFile file
+    ) {
+        if (!allowedTypes.contains(type)) {
+            return ResponseEntity.badRequest().body("잘못된 업로드 타입입니다. (character, item, quest만 허용)");
+        }
+
+        String url = s3Service.uploadFile(file, type);
+        return ResponseEntity.ok(url);
+    }
+}

--- a/domo-back/src/main/java/next/domo/upload/service/S3Service.java
+++ b/domo-back/src/main/java/next/domo/upload/service/S3Service.java
@@ -1,0 +1,65 @@
+package next.domo.upload.service;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Service;
+import org.springframework.web.multipart.MultipartFile;
+import software.amazon.awssdk.auth.credentials.AwsBasicCredentials;
+import software.amazon.awssdk.auth.credentials.StaticCredentialsProvider;
+import software.amazon.awssdk.core.sync.RequestBody;
+import software.amazon.awssdk.regions.Region;
+import software.amazon.awssdk.services.s3.S3Client;
+import software.amazon.awssdk.services.s3.model.PutObjectRequest;
+
+import java.io.IOException;
+import java.net.URLEncoder;
+import java.nio.charset.StandardCharsets;
+import java.time.LocalDateTime;
+import java.time.format.DateTimeFormatter;
+
+@Service
+@RequiredArgsConstructor
+public class S3Service {
+
+    @Value("${cloud.aws.credentials.access-key}")
+    private String accessKey;
+
+    @Value("${cloud.aws.credentials.secret-key}")
+    private String secretKey;
+
+    @Value("${cloud.aws.s3.bucket}")
+    private String bucket;
+
+    @Value("${cloud.aws.region.static}")
+    private String region;
+
+    public String uploadFile(MultipartFile file, String folder) {
+        String fileName = generateFileName(file.getOriginalFilename(), folder);
+    
+        S3Client s3 = S3Client.builder()
+                .region(Region.of(region))
+                .credentialsProvider(StaticCredentialsProvider.create(
+                        AwsBasicCredentials.create(accessKey, secretKey)))
+                .build();
+    
+        try {
+            s3.putObject(
+                    PutObjectRequest.builder()
+                            .bucket(bucket)
+                            .key(fileName)
+                            .contentType(file.getContentType())
+                            .build(),
+                    RequestBody.fromInputStream(file.getInputStream(), file.getSize()));
+        } catch (IOException e) {
+            throw new RuntimeException("S3 업로드 실패: " + e.getMessage());
+        }
+    
+        return "https://" + bucket + ".s3." + region + ".amazonaws.com/" + URLEncoder.encode(fileName, StandardCharsets.UTF_8);
+    }
+    
+    private String generateFileName(String originalName, String folder) {
+        String timestamp = LocalDateTime.now().format(DateTimeFormatter.ofPattern("yyyyMMddHHmmss"));
+        return folder + "/" + timestamp + "_" + originalName;
+    }
+    
+}

--- a/domo-back/src/main/java/next/domo/user/entity/User.java
+++ b/domo-back/src/main/java/next/domo/user/entity/User.java
@@ -67,4 +67,8 @@ public class User {
         }
         this.userCoin -= amount;
     }
+
+    public void setCharacterFileUrl(String url) {
+        this.characterFileUrl = url;
+    }
 }


### PR DESCRIPTION
* AWS S3 연동을 위한 S3Service 추가
-> S3Service는 폴더명을 인자로 받아 파일 업로드 경로 지정 가능
-> character/, item/, quest/ 경로에 따라 S3 업로드 경로 구분 가능

* 캐릭터 파일 업로드 API (/api/user/character/upload) 구현
-> 업로드한 GLB 파일을 S3에 저장하고, 해당 URL을 User 엔티티에 저장

* 캐릭터 파일 URL 조회 API (/api/user/character/url) 구현
-> User 테이블에 저장된 캐릭터 파일 URL 반환