### PR TITLE
[Feat/Mod] gpt 연동 수정 및 project 정렬/필터링 기능, item 관련 기능 추가

### DIFF
--- a/domo-back/src/main/java/next/domo/file/ItemInitializerService.java
+++ b/domo-back/src/main/java/next/domo/file/ItemInitializerService.java
@@ -1,0 +1,64 @@
+package next.domo.file;
+
+import lombok.RequiredArgsConstructor;
+import next.domo.file.entity.Item;
+import next.domo.file.repository.ItemRepository;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Service;
+import software.amazon.awssdk.auth.credentials.AwsBasicCredentials;
+import software.amazon.awssdk.auth.credentials.StaticCredentialsProvider;
+import software.amazon.awssdk.regions.Region;
+import software.amazon.awssdk.services.s3.S3Client;
+import software.amazon.awssdk.services.s3.model.ListObjectsV2Request;
+import software.amazon.awssdk.services.s3.model.ListObjectsV2Response;
+import software.amazon.awssdk.services.s3.model.S3Object;
+
+@Service
+@RequiredArgsConstructor
+public class ItemInitializerService {
+
+    private final ItemRepository itemRepository;
+
+    @Value("${cloud.aws.credentials.access-key}")
+    private String accessKey;
+
+    @Value("${cloud.aws.credentials.secret-key}")
+    private String secretKey;
+
+    @Value("${cloud.aws.s3.bucket}")
+    private String bucket;
+
+    @Value("${cloud.aws.region.static}")
+    private String region;
+
+    private final String folder = "items";
+
+    public void initializeItemsFromS3() {
+        S3Client s3 = S3Client.builder()
+                .region(Region.of(region))
+                .credentialsProvider(StaticCredentialsProvider.create(
+                        AwsBasicCredentials.create(accessKey, secretKey)))
+                .build();
+
+        ListObjectsV2Response response = s3.listObjectsV2(ListObjectsV2Request.builder()
+                .bucket(bucket)
+                .prefix(folder + "/")
+                .build());
+
+        for (S3Object object : response.contents()) {
+            String key = object.key();
+            if (key.endsWith("/")) continue;
+            String fileName = key.substring(key.lastIndexOf("/") + 1);
+            String name = fileName.replace(".glb", "");
+
+            if (itemRepository.existsByItemImageUrl("https://" + bucket + ".s3." + region + ".amazonaws.com/" + key)) continue;
+
+            Item item = Item.builder()
+                    .itemName(name)
+                    .itemImageUrl("https://" + bucket + ".s3." + region + ".amazonaws.com/" + key)
+                    .build();
+
+            itemRepository.save(item);
+        }
+    }
+}

--- a/domo-back/src/main/java/next/domo/file/controller/ItemController.java
+++ b/domo-back/src/main/java/next/domo/file/controller/ItemController.java
@@ -1,0 +1,36 @@
+package next.domo.file.controller;
+
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import lombok.RequiredArgsConstructor;
+import next.domo.file.dto.ItemResponseDto;
+import next.domo.file.service.ItemService;
+import org.springframework.http.ResponseEntity;
+import org.springframework.stereotype.Controller;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import java.util.List;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/items")
+public class ItemController {
+    private final ItemService itemService;
+
+    @Operation(summary = "아이템 전체 조회",
+            requestBody = @io.swagger.v3.oas.annotations.parameters.RequestBody(
+                    description = "조회시 요청 JSON 데이터 없음"
+            )
+    )
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "200", description = "아이템 전체 조회 성공"),
+            @ApiResponse(responseCode = "4XX", description = "아이템 전체 조회 실패")
+    })
+    @GetMapping
+    public ResponseEntity<List<ItemResponseDto>> getAllItems() {
+        return ResponseEntity.ok(itemService.getAllItems());
+    }
+}

--- a/domo-back/src/main/java/next/domo/file/dto/ItemResponseDto.java
+++ b/domo-back/src/main/java/next/domo/file/dto/ItemResponseDto.java
@@ -1,0 +1,24 @@
+package next.domo.file.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import next.domo.file.entity.Item;
+
+@Getter
+@Builder
+@AllArgsConstructor
+public class ItemResponseDto {
+
+    private Long itemId;
+    private String itemName;
+    private String itemImageUrl;
+
+    public static ItemResponseDto from(Item item) {
+        return ItemResponseDto.builder()
+                .itemId(item.getItemId())
+                .itemName(item.getItemName())
+                .itemImageUrl(item.getItemImageUrl())
+                .build();
+    }
+}

--- a/domo-back/src/main/java/next/domo/file/entity/Item.java
+++ b/domo-back/src/main/java/next/domo/file/entity/Item.java
@@ -1,0 +1,27 @@
+package next.domo.file.entity;
+
+import jakarta.persistence.*;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import next.domo.user.entity.UserItem;
+
+import java.util.ArrayList;
+import java.util.List;
+
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+@Getter
+@Entity
+public class Item {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long itemId;
+
+    private String itemName;
+
+    private String itemImageUrl;
+
+}

--- a/domo-back/src/main/java/next/domo/file/entity/Quest.java
+++ b/domo-back/src/main/java/next/domo/file/entity/Quest.java
@@ -1,0 +1,25 @@
+package next.domo.file.entity;
+
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+@Getter
+@Entity
+public class Quest {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long questId;
+
+    private String questName;
+
+    private String questFileUrl;
+}

--- a/domo-back/src/main/java/next/domo/file/repository/ItemRepository.java
+++ b/domo-back/src/main/java/next/domo/file/repository/ItemRepository.java
@@ -6,4 +6,5 @@ import org.springframework.stereotype.Repository;
 
 @Repository
 public interface ItemRepository extends JpaRepository<Item, Long> {
+    boolean existsByItemImageUrl(String imageUrl);
 }

--- a/domo-back/src/main/java/next/domo/file/repository/ItemRepository.java
+++ b/domo-back/src/main/java/next/domo/file/repository/ItemRepository.java
@@ -1,0 +1,9 @@
+package next.domo.file.repository;
+
+import next.domo.file.entity.Item;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface ItemRepository extends JpaRepository<Item, Long> {
+}

--- a/domo-back/src/main/java/next/domo/file/service/ItemService.java
+++ b/domo-back/src/main/java/next/domo/file/service/ItemService.java
@@ -1,0 +1,21 @@
+package next.domo.file.service;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.RequiredArgsConstructor;
+import next.domo.file.dto.ItemResponseDto;
+import next.domo.file.repository.ItemRepository;
+import org.springframework.stereotype.Service;
+
+import java.util.List;
+
+@Service
+@RequiredArgsConstructor
+public class ItemService {
+    private final ItemRepository itemRepository;
+    public List<ItemResponseDto> getAllItems() {
+        return itemRepository.findAll().stream()
+                .map(ItemResponseDto::from)
+                .toList();
+    }
+}

--- a/domo-back/src/main/java/next/domo/gpt/controller/GPTController.java
+++ b/domo-back/src/main/java/next/domo/gpt/controller/GPTController.java
@@ -39,8 +39,8 @@ public class GPTController {
             @ApiResponse(responseCode = "200", description = "GPT로 하위작업 생성 성공"),
             @ApiResponse(responseCode = "4XX", description = "GPT로 하위작업 생성 실패")
     })
-    @PostMapping("/{projectId}/subtasks")
-    public String createSubTaskByGPT(HttpServletRequest request, @Parameter(description = "하위작업을 생성할 프로젝트 ID", required = true, example = "1") @PathVariable Long projectId, @RequestBody GPTRequestDto GPTRequestDto) {
+    @PostMapping("/subtasks")
+    public String createSubTaskByGPT(HttpServletRequest request, @RequestBody GPTRequestDto GPTRequestDto) {
         Long userId = userService.getUserIdFromToken(request);
         return gptService.createSubTaskByGPT(userId, GPTRequestDto);
     }

--- a/domo-back/src/main/java/next/domo/init/InitRunner.java
+++ b/domo-back/src/main/java/next/domo/init/InitRunner.java
@@ -1,0 +1,18 @@
+package next.domo.init;
+
+import lombok.RequiredArgsConstructor;
+import next.domo.file.ItemInitializerService;
+import org.springframework.boot.CommandLineRunner;
+import org.springframework.stereotype.Component;
+
+@Component
+@RequiredArgsConstructor
+public class InitRunner implements CommandLineRunner {
+
+    private final ItemInitializerService itemInitializerService;
+
+    @Override
+    public void run(String... args) {
+        itemInitializerService.initializeItemsFromS3();
+    }
+}

--- a/domo-back/src/main/java/next/domo/project/controller/ProjectController.java
+++ b/domo-back/src/main/java/next/domo/project/controller/ProjectController.java
@@ -1,5 +1,8 @@
 package next.domo.project.controller;
 
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.RequiredArgsConstructor;
 import next.domo.project.dto.*;
 import next.domo.project.entity.Project;
@@ -129,4 +132,28 @@ public class ProjectController {
             projectService.completeAndRewardProject(project, levelType);
             return ResponseEntity.ok("프로젝트 완료 및 코인 계산 성공!");
         }
+
+    @Operation(summary = "프로젝트 tag별 필터링 및 정렬",
+            description = """
+            프로젝트를 정렬 기준(name, progress, deadline)에 따라 정렬하고 선택한 태그 ID 리스트(tagIds)에 해당하는 프로젝트만 필터링합니다.
+            여러 개의 tagIds를 넘기려면 ?tagIds=1&tagIds=2 형식으로 요청하세요. ex) /projects?tagIds=1&tagIds=3&sortBy=deadline
+            """
+    )
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "200", description = "프로젝트 tag별 필터링 및 정렬 성공"),
+            @ApiResponse(responseCode = "4XX", description = "프로젝트 tag별 필터링 및 정렬 실패")
+    })
+    @GetMapping("/filter")
+    public ResponseEntity<List<ProjectListResponseDto>> getProjectsByProjectTagAndSort(
+            @Parameter(
+                    description = "선택할 프로젝트 태그 ID 리스트 (여러 개 가능)",
+                    example = "1, 2"
+            )@RequestParam(required = false) List<Long> projectTagIds,
+            @Parameter(
+                    description = "정렬 기준 (name, progress, deadline 중 하나)",
+                    example = "progress"
+            ) @RequestParam(required = false) String sortBy
+    ) {
+        return ResponseEntity.ok(projectService.getProjectListResponses(projectTagIds, sortBy));
+    }
 }

--- a/domo-back/src/main/java/next/domo/project/dto/ProjectListResponseDto.java
+++ b/domo-back/src/main/java/next/domo/project/dto/ProjectListResponseDto.java
@@ -1,15 +1,27 @@
 package next.domo.project.dto;
 
 import lombok.AllArgsConstructor;
+import lombok.Builder;
 import lombok.Getter;
+import next.domo.project.entity.Project;
 
 import java.time.LocalDateTime;
 
 @Getter
+@Builder
 @AllArgsConstructor
 public class ProjectListResponseDto {
     private Long projectId;
     private String projectName;
     private String projectTagName;
     private LocalDateTime projectDeadline;
+
+    public static ProjectListResponseDto from(Project project) {
+        return ProjectListResponseDto.builder()
+                .projectId(project.getProjectId())
+                .projectName(project.getProjectName())
+                .projectTagName(project.getProjectTag().getProjectTagName())
+                .projectDeadline(project.getProjectDeadline())
+                .build();
+    }
 }

--- a/domo-back/src/main/java/next/domo/project/repository/ProjectRepository.java
+++ b/domo-back/src/main/java/next/domo/project/repository/ProjectRepository.java
@@ -1,6 +1,7 @@
 package next.domo.project.repository;
 
 import next.domo.project.entity.Project;
+import org.springframework.data.domain.Sort;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
@@ -12,4 +13,6 @@ public interface ProjectRepository extends JpaRepository<Project, Long> {
     boolean existsByProjectTag_ProjectTagId(Long projectTagId);
     List<Project> findByUserUserId(Long userId);
     Optional<Project> findTopByUserUserIdOrderByProjectIdDesc(Long userId);
+    List<Project> findByProjectTag_ProjectTagIdIn(List<Long> tagIds, Sort sort);
+    List<Project> findAll(Sort sort);
 }

--- a/domo-back/src/main/java/next/domo/project/service/ProjectService.java
+++ b/domo-back/src/main/java/next/domo/project/service/ProjectService.java
@@ -13,6 +13,7 @@ import next.domo.user.repository.UserRepository;
 import next.domo.user.service.UserService;
 import next.domo.user.service.UserTagService;
 
+import org.springframework.data.domain.Sort;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -187,7 +188,28 @@ public class ProjectService {
 
         //  사용자 하위작업 태그 예측 대비 소요율 갱신
         userTagService.updateUserTagRates(user);
-}
+    }
+
+    public List<ProjectListResponseDto> getProjectListResponses(List<Long> projectTagIds, String sortBy) {
+        Sort sort = switch (sortBy) {
+            case "name" -> Sort.by("projectName").ascending();
+            case "progress" -> Sort.by("projectProgressRate").descending();
+            case "deadline" -> Sort.by("projectDeadline").ascending();
+            default -> Sort.unsorted();
+        };
+
+        List<Project> projects;
+
+        if (projectTagIds != null && !projectTagIds.isEmpty()) {
+            projects = projectRepository.findByProjectTag_ProjectTagIdIn(projectTagIds, sort);
+        } else {
+            projects = projectRepository.findAll(sort);
+        }
+
+        return projects.stream()
+                .map(ProjectListResponseDto::from)
+                .toList();
+    }
 
 }
 

--- a/domo-back/src/main/java/next/domo/user/controller/UserController.java
+++ b/domo-back/src/main/java/next/domo/user/controller/UserController.java
@@ -1,12 +1,11 @@
 package next.domo.user.controller;
 
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 import lombok.RequiredArgsConstructor;
-import next.domo.user.dto.ChangePasswordRequestDto;
-import next.domo.user.dto.UserLoginRequestDto;
-import next.domo.user.dto.UserOnboardingRequestDto;
-import next.domo.user.dto.UserSignUpRequestDto;
+import next.domo.user.dto.*;
 import next.domo.user.service.UserService;
 
 import org.springframework.http.ResponseEntity;
@@ -151,5 +150,49 @@ public class UserController {
         }
         
         return ResponseEntity.ok(url);
+    }
+
+    @Operation(summary = "예상소요시간 계산 선호도 수정",
+            requestBody = @io.swagger.v3.oas.annotations.parameters.RequestBody(
+                    description = "수정할 예상소요시간 계산 선호도 JSON 데이터",
+                    required = true,
+                    content = @Content(
+                            schema = @Schema(
+                                    type = "object",
+                                    example = "{\n \"workPace\": \"TIGHT\"  }"
+                            )
+                    )
+            ))
+    @ApiResponses({
+            @ApiResponse(responseCode = "200", description = "예상소요시간 계산 선호도 수정 성공"),
+            @ApiResponse(responseCode = "400", description = "예상소요시간 계산 선호도 수정 실패")
+    })
+    @PatchMapping("/users/work-pace")
+    public ResponseEntity<Void> updateWorkPace(HttpServletRequest request, @RequestBody UpdateWorkPaceRequestDto updateWorkPaceRequestDto) {
+        Long userId = userService.getUserIdFromToken(request);
+        userService.updateWorkPace(userId, updateWorkPaceRequestDto);
+        return ResponseEntity.ok().build();
+    }
+
+    @Operation(summary = "세부화 선호도 수정",
+            requestBody = @io.swagger.v3.oas.annotations.parameters.RequestBody(
+                    description = "세부화 선호도 JSON 데이터",
+                    required = true,
+                    content = @Content(
+                            schema = @Schema(
+                                    type = "object",
+                                    example = "{\n \"detailPreference\": \"MANY_TASKS\"  }"
+                            )
+                    )
+            ))
+    @ApiResponses({
+            @ApiResponse(responseCode = "200", description = "세부화 선호도 수정 성공"),
+            @ApiResponse(responseCode = "400", description = "세부화 선호도 수정 실패")
+    })
+    @PatchMapping("/users/detail-preference")
+    public ResponseEntity<Void> updateDetailPreference(HttpServletRequest request, @RequestBody UpdateDetailPreferenceRequestDto updateDetailPreferenceRequestDto) {
+        Long userId = userService.getUserIdFromToken(request);
+        userService.updateDetailPreference(userId, updateDetailPreferenceRequestDto);
+        return ResponseEntity.ok().build();
     }
 }

--- a/domo-back/src/main/java/next/domo/user/controller/UserItemController.java
+++ b/domo-back/src/main/java/next/domo/user/controller/UserItemController.java
@@ -1,0 +1,68 @@
+package next.domo.user.controller;
+
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.parameters.RequestBody;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import jakarta.servlet.http.HttpServletRequest;
+import lombok.RequiredArgsConstructor;
+import next.domo.user.dto.UserItemRequestDto;
+import next.domo.user.dto.UserItemStoreResponseDto;
+import next.domo.user.service.UserItemService;
+import next.domo.user.service.UserService;
+import org.springframework.http.ResponseEntity;
+import org.springframework.stereotype.Controller;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import java.util.List;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/user-items")
+public class UserItemController {
+    private final UserService userService;
+    private final UserItemService userItemService;
+
+    @Operation(summary = "사용자 아이템 선택 (유저 아이템 등록)",
+            requestBody = @io.swagger.v3.oas.annotations.parameters.RequestBody(
+                    description = "선택한 아이템 JSON 데이터",
+                    required = true,
+                    content = @Content(
+                            schema = @Schema(
+                                    type = "object",
+                                    example = "{\n \"itemId\": \"1\" }"
+                            )
+                    )
+            )
+    )
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "200", description = "사용자 아이템 선택 성공"),
+            @ApiResponse(responseCode = "4XX", description = "사용자 아이템 선택 실패")
+    })
+    @PostMapping("")
+    public ResponseEntity<Void> selectItem(HttpServletRequest request, @RequestBody UserItemRequestDto userItemRequestDto) {
+        Long userId = userService.getUserIdFromToken(request);
+        userItemService.addItemToUser(userId, userItemRequestDto);
+        return ResponseEntity.ok().build();
+    }
+
+    @Operation(summary = "사용자의 item store 조회 (사용자 소유 여부 포함)",
+            requestBody = @io.swagger.v3.oas.annotations.parameters.RequestBody(
+                    description = "조회시 요청 JSON 데이터 없음"
+            )
+    )
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "200", description = "사용자의 item store 조회 성공"),
+            @ApiResponse(responseCode = "4XX", description = "사용자의 item store 조회 실패")
+    })
+    @GetMapping("/store")
+    public ResponseEntity<List<UserItemStoreResponseDto>> getStoreItems(HttpServletRequest request) {
+        Long userId = userService.getUserIdFromToken(request);
+        return ResponseEntity.ok(userItemService.getStoreItemsByUser(userId));
+    }
+}

--- a/domo-back/src/main/java/next/domo/user/dto/UpdateDetailPreferenceRequestDto.java
+++ b/domo-back/src/main/java/next/domo/user/dto/UpdateDetailPreferenceRequestDto.java
@@ -1,0 +1,9 @@
+package next.domo.user.dto;
+
+import lombok.Getter;
+import next.domo.user.enums.TaskDetailPreference;
+
+@Getter
+public class UpdateDetailPreferenceRequestDto {
+    private TaskDetailPreference detailPreference;
+}

--- a/domo-back/src/main/java/next/domo/user/dto/UpdateWorkPaceRequestDto.java
+++ b/domo-back/src/main/java/next/domo/user/dto/UpdateWorkPaceRequestDto.java
@@ -1,0 +1,10 @@
+package next.domo.user.dto;
+
+import lombok.Getter;
+import next.domo.user.enums.WorkPace;
+
+@Getter
+public class UpdateWorkPaceRequestDto {
+    private WorkPace workPace;
+
+}

--- a/domo-back/src/main/java/next/domo/user/dto/UserItemRequestDto.java
+++ b/domo-back/src/main/java/next/domo/user/dto/UserItemRequestDto.java
@@ -1,0 +1,8 @@
+package next.domo.user.dto;
+
+import lombok.Getter;
+
+@Getter
+public class UserItemRequestDto {
+    private Long itemId;
+}

--- a/domo-back/src/main/java/next/domo/user/dto/UserItemStoreResponseDto.java
+++ b/domo-back/src/main/java/next/domo/user/dto/UserItemStoreResponseDto.java
@@ -1,0 +1,25 @@
+package next.domo.user.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import next.domo.file.entity.Item;
+
+@Builder
+@AllArgsConstructor
+@Getter
+public class UserItemStoreResponseDto {
+    private Long id;
+    private String name;
+    private String imageUrl;
+    private boolean hasItem;
+
+    public static UserItemStoreResponseDto from(Item item, boolean hasItem) {
+        return UserItemStoreResponseDto.builder()
+                .id(item.getItemId())
+                .name(item.getItemName())
+                .imageUrl(item.getItemImageUrl())
+                .hasItem(hasItem)
+                .build();
+    }
+}

--- a/domo-back/src/main/java/next/domo/user/entity/User.java
+++ b/domo-back/src/main/java/next/domo/user/entity/User.java
@@ -1,15 +1,12 @@
 package next.domo.user.entity;
 
-import jakarta.persistence.Entity;
-import jakarta.persistence.GeneratedValue;
-import jakarta.persistence.GenerationType;
-import jakarta.persistence.Id;
+import jakarta.persistence.*;
 import lombok.*;
-import jakarta.persistence.Table;
-import jakarta.persistence.Enumerated;
-import jakarta.persistence.EnumType;
 import next.domo.user.enums.TaskDetailPreference;
 import next.domo.user.enums.WorkPace;
+
+import java.util.ArrayList;
+import java.util.List;
 
 
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
@@ -47,11 +44,11 @@ public class User {
         this.password = newPassword;
     }
 
-    public void setDetailPreference(TaskDetailPreference detailPreference) {
+    public void updateDetailPreference (TaskDetailPreference detailPreference) {
         this.detailPreference = detailPreference;
     }
     
-    public void setWorkPace(WorkPace workPace) {
+    public void updateWorkPace(WorkPace workPace) {
         this.workPace = workPace;
     }
 

--- a/domo-back/src/main/java/next/domo/user/entity/UserItem.java
+++ b/domo-back/src/main/java/next/domo/user/entity/UserItem.java
@@ -1,0 +1,27 @@
+package next.domo.user.entity;
+
+import jakarta.persistence.*;
+import lombok.*;
+import next.domo.file.entity.Item;
+
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+@Getter
+@Entity
+public class UserItem {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long userItemId;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "user_id", nullable = false)
+    private User user;
+
+    // ✅ Item 단방향 연관관계
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "item_id", nullable = false)
+    private Item item;
+
+
+}

--- a/domo-back/src/main/java/next/domo/user/repository/UserItemRepository.java
+++ b/domo-back/src/main/java/next/domo/user/repository/UserItemRepository.java
@@ -1,0 +1,13 @@
+package next.domo.user.repository;
+
+import next.domo.user.entity.UserItem;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+
+import java.util.List;
+
+public interface UserItemRepository extends JpaRepository<UserItem, Long> {
+    @Query("SELECT ui.item.itemId FROM UserItem ui WHERE ui.user.userId = :userId")
+    List<Long> findItemIdsByUserId(@Param("userId") Long userId);
+}

--- a/domo-back/src/main/java/next/domo/user/service/UserItemService.java
+++ b/domo-back/src/main/java/next/domo/user/service/UserItemService.java
@@ -1,0 +1,48 @@
+package next.domo.user.service;
+
+import jakarta.transaction.Transactional;
+import lombok.RequiredArgsConstructor;
+import next.domo.file.entity.Item;
+import next.domo.file.repository.ItemRepository;
+import next.domo.user.dto.UserItemRequestDto;
+import next.domo.user.dto.UserItemStoreResponseDto;
+import next.domo.user.entity.User;
+import next.domo.user.entity.UserItem;
+import next.domo.user.repository.UserItemRepository;
+import next.domo.user.repository.UserRepository;
+import org.springframework.stereotype.Service;
+
+import java.util.List;
+
+@RequiredArgsConstructor
+@Service
+public class UserItemService {
+    private final UserRepository userRepository;
+    private final ItemRepository itemRepository;
+    private final UserItemRepository userItemRepository;
+
+    @Transactional
+    public void addItemToUser(Long userId, UserItemRequestDto userItemRequestDto) {
+        User user = userRepository.findById(userId)
+                .orElseThrow(() -> new IllegalArgumentException("User not found"));
+
+        Item item = itemRepository.findById(userItemRequestDto.getItemId())
+                .orElseThrow(() -> new IllegalArgumentException("Item not found"));
+
+        UserItem userItem = UserItem.builder()
+                .user(user)
+                .item(item)
+                .build();
+
+        userItemRepository.save(userItem);
+    }
+
+    public List<UserItemStoreResponseDto> getStoreItemsByUser(Long userId) {
+        List<Item> allItems = itemRepository.findAll();
+        List<Long> ownedItemIds = userItemRepository.findItemIdsByUserId(userId);
+
+        return allItems.stream()
+                .map(item -> UserItemStoreResponseDto.from(item, ownedItemIds.contains(item.getItemId())))
+                .toList();
+    }
+}

--- a/domo-back/src/main/java/next/domo/user/service/UserService.java
+++ b/domo-back/src/main/java/next/domo/user/service/UserService.java
@@ -6,12 +6,11 @@ import lombok.RequiredArgsConstructor;
 import next.domo.jwt.JwtProvider;
 import next.domo.project.entity.ProjectTag;
 import next.domo.project.repository.ProjectTagRepository;
-import next.domo.user.dto.ChangePasswordRequestDto;
-import next.domo.user.dto.UserLoginRequestDto;
-import next.domo.user.dto.UserOnboardingRequestDto;
-import next.domo.user.dto.UserSignUpRequestDto;
+import next.domo.user.dto.*;
 import next.domo.user.entity.User;
 import next.domo.user.enums.OnboardingTagType;
+import next.domo.user.enums.TaskDetailPreference;
+import next.domo.user.enums.WorkPace;
 import next.domo.user.repository.UserRepository;
 import next.domo.upload.service.S3Service;
 
@@ -122,8 +121,8 @@ public class UserService {
         User user = userRepository.findById(userId)
         .orElseThrow(() -> new RuntimeException("유저를 찾을 수 없습니다."));
         
-        user.setDetailPreference(requestDto.getDetailPreference());
-        user.setWorkPace(requestDto.getWorkPace());
+        user.updateDetailPreference(requestDto.getDetailPreference());
+        user.updateWorkPace(requestDto.getWorkPace());
         
         // 관심 태그 기반 project tag 자동 생성
         for (OnboardingTagType tagEnum : requestDto.getInterestedTags()) {
@@ -187,5 +186,16 @@ public class UserService {
             .orElseThrow(() -> new RuntimeException("사용자를 찾을 수 없습니다."));
         return user.getCharacterFileUrl();
     }
-    
+
+    public void updateWorkPace(Long userId, UpdateWorkPaceRequestDto updateWorkPaceRequestDto) {
+        User user = userRepository.findById(userId)
+                .orElseThrow(() -> new IllegalArgumentException("사용자를 찾을 수 없습니다."));
+        user.updateWorkPace(updateWorkPaceRequestDto.getWorkPace());
+    }
+
+    public void updateDetailPreference(Long userId, UpdateDetailPreferenceRequestDto updateDetailPreferenceRequestDto) {
+        User user = userRepository.findById(userId)
+                .orElseThrow(() -> new IllegalArgumentException("사용자를 찾을 수 없습니다."));
+        user.updateDetailPreference(updateDetailPreferenceRequestDto.getDetailPreference());
+    }
 }


### PR DESCRIPTION
### 추가한 부분
- GPT 연동 기능 개선  
  - 프롬프트 수정: 사용자 성향 및 예측 소요시간 단위를 분(minute) 기준으로 변경

- 프로젝트(Project) 기능 확장  
  - 정렬 기능 추가: 이름순, 진행률순, 마감일순 정렬 지원  
  - 필터링 기능 추가: 태그 기반 필터링 가능

- 사용자(User) 설정 기능 추가  
  - 작업 여유 성향(workPace) 수정  
  - 세분화 선호도(detailPreference) 수정

- 아이템(Item) 관련 기능 추가  
  - 전체 아이템 조회  
  - 사용자 보유 여부(hasItem) 포함하여 조회  
  - 사용자 아이템 획득 기능 추가 (`UserItem` 등록)

- S3 연동  
  - S3 `items/` 폴더에 저장된 파일들을 서버 시작 시 일괄적으로 DB에 등록되도록 초기화 로직 구현