### PR TITLE
[Mod] 가장 최근 접속한 프로젝트 기능 수정

### DIFF
--- a/domo-back/src/main/java/next/domo/project/controller/ProjectController.java
+++ b/domo-back/src/main/java/next/domo/project/controller/ProjectController.java
@@ -87,8 +87,11 @@ public class ProjectController {
         @ApiResponse(responseCode = "400", description = "최근 프로젝트 조회 실패")
     })
     @GetMapping("/recent")
-    public ResponseEntity<ProjectListResponseDto> getRecentProject() {
+    public ResponseEntity<?> getRecentProject() {
         ProjectListResponseDto recent = projectService.getRecentProject();
+        if (recent == null) {
+            return ResponseEntity.ok("최근 접속한 프로젝트가 없습니다.");
+        }
         return ResponseEntity.ok(recent);
     }
 

--- a/domo-back/src/main/java/next/domo/project/entity/Project.java
+++ b/domo-back/src/main/java/next/domo/project/entity/Project.java
@@ -45,7 +45,8 @@ public class Project {
 
     private Integer projectCoin;
 
-    private LocalDateTime lastAccessedAt;
+    @Column(nullable = false)
+    private LocalDateTime lastAccessedAt = LocalDateTime.now();
 
     public void updateProject(String projectName, String projectDescription, String projectRequirement, LocalDateTime projectDeadline, ProjectTag projectTag) {
         this.projectName = projectName;

--- a/domo-back/src/main/java/next/domo/project/service/ProjectService.java
+++ b/domo-back/src/main/java/next/domo/project/service/ProjectService.java
@@ -73,7 +73,6 @@ public class ProjectService {
                 .orElseThrow(() -> new RuntimeException("프로젝트를 찾을 수 없습니다."));
 
         project.updateLastAccessedAt();
-        projectRepository.save(project);
 
         return new ProjectDetailResponseDto(
                 project.getProjectName(),
@@ -120,9 +119,9 @@ public class ProjectService {
 
     public ProjectListResponseDto getRecentProject() {
         Long userId = userService.getCurrentUserId();
-        Project recent = projectRepository.findTopByUserUserIdOrderByLastAccessedAtDesc(userId)
-                .orElseThrow(() -> new RuntimeException("최근 프로젝트가 없습니다."));
-        return ProjectListResponseDto.from(recent);
+        return projectRepository.findTopByUserUserIdOrderByLastAccessedAtDesc(userId)
+                .map(ProjectListResponseDto::from)
+                .orElse(null); // ❗ 예외 대신 null 반환
     }
 
     public void updateProjectExpectedTime(Long projectId) {


### PR DESCRIPTION
최근 프로젝트 불러오기에서 프로젝트 없으면 해당 부분에 ‘최근 접속한 프로젝트가 없습니다.’ 띄우기
-> 이미 구현되어있는데,
예외 발생 → RuntimeException → 컨트롤러까지 올라가면서 403 반환됨
→ null 처리 → 메세지 띄우기로 변경