### PR TITLE
[Mod] delete cascade 설정 추가

### DIFF
--- a/domo-back/src/main/java/next/domo/project/entity/Project.java
+++ b/domo-back/src/main/java/next/domo/project/entity/Project.java
@@ -27,6 +27,7 @@ public class Project {
 
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "project_tag_id", nullable = false)
+    @OnDelete(action = OnDeleteAction.CASCADE)
     private ProjectTag projectTag;
 
     private String projectName;

--- a/domo-back/src/main/java/next/domo/project/entity/ProjectTag.java
+++ b/domo-back/src/main/java/next/domo/project/entity/ProjectTag.java
@@ -3,6 +3,8 @@ package next.domo.project.entity;
 import jakarta.persistence.*;
 import lombok.*;
 import next.domo.user.entity.User;
+import org.hibernate.annotations.OnDelete;
+import org.hibernate.annotations.OnDeleteAction;
 
 @Entity
 @Table(name = "project_tag")
@@ -20,5 +22,6 @@ public class ProjectTag {
 
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "user_id", nullable = false)
+    @OnDelete(action = OnDeleteAction.CASCADE)
     private User user;
 }

--- a/domo-back/src/main/java/next/domo/user/entity/UserItem.java
+++ b/domo-back/src/main/java/next/domo/user/entity/UserItem.java
@@ -3,6 +3,8 @@ package next.domo.user.entity;
 import jakarta.persistence.*;
 import lombok.*;
 import next.domo.file.entity.Item;
+import org.hibernate.annotations.OnDelete;
+import org.hibernate.annotations.OnDeleteAction;
 
 import java.time.LocalDateTime;
 
@@ -18,10 +20,12 @@ public class UserItem {
 
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "user_id", nullable = false)
+    @OnDelete(action = OnDeleteAction.CASCADE)
     private User user;
 
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "item_id", nullable = false)
+    @OnDelete(action = OnDeleteAction.CASCADE)
     private Item item;
 
     private LocalDateTime equippedAt;

--- a/domo-back/src/main/java/next/domo/user/entity/UserTag.java
+++ b/domo-back/src/main/java/next/domo/user/entity/UserTag.java
@@ -3,6 +3,8 @@ package next.domo.user.entity;
 import jakarta.persistence.*;
 import lombok.*;
 import next.domo.subtask.entity.SubTaskTag;
+import org.hibernate.annotations.OnDelete;
+import org.hibernate.annotations.OnDeleteAction;
 
 @Entity
 @Getter
@@ -18,6 +20,7 @@ public class UserTag {
 
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "userId", nullable = false)
+    @OnDelete(action = OnDeleteAction.CASCADE)
     private User user;
 
     @Column(nullable = false)


### PR DESCRIPTION
### 문제 상황
- 회원 탈퇴가 연관관계 문제 때문에 안되는 상황
  - user_id를 참조하고 있는 다른 테이블(project_tag)에 아직 데이터가 남아 있어서 삭제가 불가능
 

### 수정한 코드
- 엔티티 간의 관계를 JPA의 매핑 설정(cascade 등)을 통해 자동으로 관리
  - User -> UserTag, User/Item -> UserItem, User -> ProjectTag, ProjectTag -> Project 
  - 앞의 엔티티가 삭제시 연결된 뒤의 엔티티도 같이 삭제됨